### PR TITLE
Fix dynamic switch failure using Elixir 1.4

### DIFF
--- a/lib/mix/tasks/exgen.new.ex
+++ b/lib/mix/tasks/exgen.new.ex
@@ -18,10 +18,10 @@ defmodule Mix.Tasks.Exgen.New do
     end
   end
 
-  defp parse_args(args) do
+  def parse_args(args) do
 
     switches = [template: :string]
-    {opts, args, _} = OptionParser.parse(args, switches: switches, aliases: [t: :template])
+    {opts, args, _} = OptionParser.parse(args, switches: switches, aliases: [t: :template], allow_nonexistent_atoms: true)
 
     default_opts = []
     opts = Keyword.merge(default_opts, opts)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExGen.Mixfile do
 
   def project do
     [app: :exgen,
-     version: "0.5.1",
+     version: "0.5.2",
      elixir: ">= 1.3.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},

--- a/test/mix/tasks/exgen.new_test.exs
+++ b/test/mix/tasks/exgen.new_test.exs
@@ -89,4 +89,15 @@ defmodule Mix.Tasks.Exgen.NewTest do
       end
     end
   end
+
+  describe "exgen.new with dynamic switches" do
+
+    test "parses dynamic switches" do
+      args = ["some_app", "-t", "https://github.com/rwdaigle/exgen-plug-simple.git", "--app-name", "some_app", "--module", "SomeApp"]
+      {:ok, target, opts} = Mix.Tasks.Exgen.New.parse_args(args)
+      expected_opts = [template: "https://github.com/rwdaigle/exgen-plug-simple.git", app_name: "some_app", module: "SomeApp"]
+      assert opts == expected_opts
+    end
+
+  end
 end


### PR DESCRIPTION
Using Elixir 1.4.2, exgen has an issue at runtime where it does not
parse the args correctly.  This seems to be related to a change in the
OptionParser in Elixir 1.4.

To fix we have to pass the `allow_nonexistent_atoms: true` option to the
OptionsParser.

Backwards compatible to at least 1.3.

Closes rwdaigle/exgen#1.